### PR TITLE
Link to public technical documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ ART is a tool that leverages machine learning and probabilistic modeling techniq
 
 Please note that this repository does not contain ART source code. For information on how to access the library see the [License](#license) section.
 
-Please find more details about ART at the [ART website](https://sites.google.com/lbl.gov/art).
-
-
+See the [ART website](https://sites.google.com/lbl.gov/art) for programmatic updates and mentions of ART in the media.  Also see
+the [technical documentation site](https://lbl-biosci.gitlab.io/ese/art/).
 
 <!-- - [Documentation](#documentation) -->
 - [System Requirements](#system-requirements)


### PR DESCRIPTION
Updated the README to include a link to ART's new, public-facing [technical documentation site](https://lbl-biosci.gitlab.io/ese/art/).

Hopefully in the near future we can completely remove duplicate notebooks in this public-facing repo once minor latex formula rendering issues in the rendered documentation site have been addressed.